### PR TITLE
Add rootstock derivation path

### DIFF
--- a/src/device/addresses.ts
+++ b/src/device/addresses.ts
@@ -6,6 +6,7 @@ const paths = {
   ledger: (index: number) => `44'/60'/0'/${index}`,
   ledgerLive: (index: number) => `44'/60'/${index}'/0/0`,
   bip44: (index: number) => `44'/60'/0'/0/${index}`,
+  rootstock: (index: number) => `44'/137'/0'/0/${index}`,
 };
 
 type PathType = keyof typeof paths;


### PR DESCRIPTION
## Description

This PR add support for Rootstock network derivation path. This is required for Rootstock <> Ledger connection support in zerion extension wallet. 

## Why 

To enable ledger connection with Rootstock nano app in zerion extension wallet where Rootstock as network is already supported and used by users. Merging and releasing this PR will help to enable ledger connection in zerion extension for Rootstock.